### PR TITLE
Include trade hash on block root

### DIFF
--- a/Bizanc.io.Matching.Core/Domain/Chain.cs
+++ b/Bizanc.io.Matching.Core/Domain/Chain.cs
@@ -908,6 +908,8 @@ namespace Bizanc.io.Matching.Core.Domain
                             Console.WriteLine("Block with invalid trade");
                             return null;
                         }
+
+                        root = CryptoHelper.Hash(Base58.Bitcoin.Encode(new Span<Byte>(root)) + t.ToString());
                     }
 
                     clone.Trades = of.Trades;

--- a/Bizanc.io.Matching.Core/Domain/Immutable/Book.cs
+++ b/Bizanc.io.Matching.Core/Domain/Immutable/Book.cs
@@ -134,6 +134,9 @@ namespace Bizanc.io.Matching.Core.Domain.Immutable
                 {
                     clone.Finish();
                     ellegibles.Add(clone);
+                    foreach(var t in clone.Trades)
+                        root = CryptoHelper.Hash(Base58.Bitcoin.Encode(new Span<Byte>(root)) + t.ToString());
+                        
                     root = CryptoHelper.Hash(Base58.Bitcoin.Encode(new Span<Byte>(root)) + clone.ToString());
                 }
             }

--- a/Bizanc.io.Matching.Core/Domain/Trade.cs
+++ b/Bizanc.io.Matching.Core/Domain/Trade.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Globalization;
 
 namespace Bizanc.io.Matching.Core.Domain
 {
@@ -50,6 +51,13 @@ namespace Bizanc.io.Matching.Core.Domain
                     this.Quantity == trade.Quantity &&
                     this.Seller == trade.Seller &&
                     this.SellerWallet == trade.SellerWallet;
+        }
+
+        public override string ToString()
+        {
+            return Asset + DtTrade.ToUniversalTime().Ticks + Buyer + BuyerWallet +
+                Seller + SellerWallet + Quantity.ToString("0.0000000000000000000000000", CultureInfo.GetCultureInfo("En-US")) +
+                Price.ToString("0.0000000000000000000000000", CultureInfo.GetCultureInfo("En-US"));
         }
     }
 }


### PR DESCRIPTION
Nodes validates each trade by the block producer and include it on block hash root. resolve #4 