### PR TITLE
Fix Stack Overflow for new synchs

### DIFF
--- a/Bizanc.io.Matching.Core/Domain/Chain.cs
+++ b/Bizanc.io.Matching.Core/Domain/Chain.cs
@@ -139,6 +139,36 @@ namespace Bizanc.io.Matching.Core.Domain
             return result;
         }
 
+        public List<Block> GetBlocksOldToNew(long offset)
+        {
+            var result = new List<Block>();
+            var current = this;
+
+            while (current != null && current.CurrentBlock != null && current.CurrentBlock.Header.Depth >= offset)
+            {
+                result.Insert(0, current.CurrentBlock);
+
+                current = current.Previous;
+            }
+
+            return result;
+        }
+
+        public List<Block> GetBlocksOldToNew(DateTime lastDateTime)
+        {
+            var result = new List<Block>();
+            var current = this;
+
+            while (current != null && current.CurrentBlock != null && current.CurrentBlock.Header.TimeStamp >= lastDateTime)
+            {
+                result.Insert(0, current.CurrentBlock);
+
+                current = current.Previous;
+            }
+
+            return result;
+        }
+
         public async Task<List<Transaction>> GetAllTransactions()
         {
             var result = new List<Transaction>();

--- a/Bizanc.io.Matching.Core/Domain/Chain.cs
+++ b/Bizanc.io.Matching.Core/Domain/Chain.cs
@@ -107,44 +107,34 @@ namespace Bizanc.io.Matching.Core.Domain
         public async Task<ICollection<OfferCancel>> GetOfferCancelPool() => await Pool.OfferCancelPool.GetPool();
 
 
-        public List<Block> GetBlocksNewToOld(List<Block> result = null)
+        public List<Block> GetBlocksNewToOld()
         {
-            if (result == null)
-                result = new List<Block>();
+            var result = new List<Block>();
+            var current = this;
 
-            if (CurrentBlock != null)
-                result.Add(CurrentBlock);
+            while (current != null)
+            {
+                if (current.CurrentBlock != null)
+                    result.Add(current.CurrentBlock);
 
-            if (Previous != null)
-                result = Previous.GetBlocksNewToOld(result);
+                current = current.Previous;
+            }
 
             return result;
         }
 
-        public List<Block> GetBlocksNewToOld(int skip, List<Block> result = null)
+        public List<Block> GetBlocksOldToNew()
         {
-            if (result == null)
-                result = new List<Block>();
+            var result = new List<Block>();
+            var current = this;
 
-            if (CurrentBlock != null && skip == 0)
-                result.Add(CurrentBlock);
+            while (current != null)
+            {
+                if (current.CurrentBlock != null)
+                    result.Insert(0, current.CurrentBlock);
 
-            if (Previous != null)
-                result = Previous.GetBlocksNewToOld(--skip, result);
-
-            return result;
-        }
-
-        public List<Block> GetBlocksOldToNew(List<Block> result = null)
-        {
-            if (result == null)
-                result = new List<Block>();
-
-            if (Previous != null)
-                result = Previous.GetBlocksOldToNew(result);
-
-            if (CurrentBlock != null)
-                result.Add(CurrentBlock);
+                current = current.Previous;
+            }
 
             return result;
         }

--- a/Bizanc.io.Matching.Core/Domain/Miner.cs
+++ b/Bizanc.io.Matching.Core/Domain/Miner.cs
@@ -1760,11 +1760,11 @@ namespace Bizanc.io.Matching.Core.Domain
             try
             {
                 var result = new List<Block>();
-                var chainBlocks = chain.GetBlocksOldToNew();
+                var chainBlocks = chain.GetBlocksOldToNew(offSet);
                 if (chainBlocks.Count == 0)
                     return result;
 
-                var blocksToSend = chainBlocks.Where(b => b.Header.Depth >= offSet).OrderBy(b => b.Header.Depth).ToList();
+                var blocksToSend = chainBlocks.OrderBy(b => b.Header.Depth).ToList();
 
                 if (blocksToSend.Count > 0 && offSet < blocksToSend.First().Header.Depth)
                 {
@@ -1791,7 +1791,7 @@ namespace Bizanc.io.Matching.Core.Domain
         public async Task GetBlocks(long offSet, IPeer sender)
         {
             var blockResponse = new BlockResponse();
-            var chainBlocks = chain.GetBlocksOldToNew();
+            var chainBlocks = chain.GetBlocksOldToNew(offSet);
             if (chainBlocks.Count == 0)
             {
                 blockResponse.End = true;
@@ -1978,7 +1978,7 @@ namespace Bizanc.io.Matching.Core.Domain
         {
             var stats = await blockRepository.GetBlockStats();
             stats.Blocks.LastBlockTime = chain.CurrentBlock.Timestamp;
-            var chainBlocks = chain.GetBlocksOldToNew();
+            var chainBlocks = chain.GetBlocksOldToNew(DateTime.Now.ToUniversalTime().AddHours(-24));
             if (stats.Blocks.TotalCount == 0)
                 stats.Blocks.FirstBlockTime = chainBlocks.First().Timestamp;
             stats.Blocks.TotalCount += chainBlocks.Count;


### PR DESCRIPTION
Given the chain growth, traversing the chain recursively started raising stack overflow exceptions. This pull request removes recursive traverse and creates method overloads to limit the elements.